### PR TITLE
fix(modal): modify opacity to shield in modal

### DIFF
--- a/packages/konstellation-web-components/src/styles/_colors.scss
+++ b/packages/konstellation-web-components/src/styles/_colors.scss
@@ -115,4 +115,4 @@ $color-dashboard: (
 );
 
 $color-shield: white;
-$opacity-shield: 0.1;
+$opacity-shield: 0.25;


### PR DESCRIPTION
The actual opacity is 0.1, which is too low. To follow the desired design, the opacity should be higher and, for consistence, this change modify the opacity every time you use a kwc modal.