### PR TITLE
fix(modal): add close button to modal header

### DIFF
--- a/packages/konstellation-web-components/src/components/LayoutComponents/ModalContainer/ModalContainer.module.scss
+++ b/packages/konstellation-web-components/src/components/LayoutComponents/ModalContainer/ModalContainer.module.scss
@@ -36,11 +36,22 @@
   padding-right: 21px;
 }
 
-.title {
-  @include font-caption;
-  color: white;
-  text-transform: uppercase;
+.header {
+  display: flex;
+  justify-content: space-between;
+  padding-right: 18px;
+  .title {
+    @include font-caption;
+    color: white;
+    text-transform: uppercase;
+  }
+  .close {
+    color: font-color(lowlight);
+    padding: 0;
+    width: 14px;
+  }
 }
+
 
 .subtitle {
   @include font-body;

--- a/packages/konstellation-web-components/src/components/LayoutComponents/ModalContainer/ModalContainer.tsx
+++ b/packages/konstellation-web-components/src/components/LayoutComponents/ModalContainer/ModalContainer.tsx
@@ -1,5 +1,6 @@
 import { BUTTON_THEMES, Button } from '../../Button/Button';
 import React, { Fragment, FunctionComponent, MouseEvent } from 'react';
+import CloseIcon from '@material-ui/icons/Close';
 
 import { HorizontalBar } from '../HorizontalBar/HorizontalBar';
 import cx from 'classnames';
@@ -63,7 +64,17 @@ export const ModalContainer: FunctionComponent<ModalContainerProps> = ({
           [styles.error]: error,
         })}
       >
-        <div className={styles.title}>{title}</div>
+        <div className={styles.header}>
+          <div className={styles.title}>{title}</div>
+          <Button
+            className={styles.close}
+            onClick={onCancel}
+            Icon={CloseIcon}
+            iconSize="icon-small"
+            height={14}
+            label=""
+          />
+        </div>
         <div className={styles.subtitle}>{subtitle}</div>
         <div className={styles.content}>{children}</div>
         <div className={styles.footer}>


### PR DESCRIPTION
Add x icon to close modals. For consistency, this is added directly in kwc, this way all modals will have close buttons.

![image](https://user-images.githubusercontent.com/37367294/156161108-5443bd70-2ce4-4135-bc72-bf6ce127f13c.png)
